### PR TITLE
fix local and up README

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,5 @@
 {
   "root": true,
-  // "parser": "babel-eslint",
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaFeatures": {
@@ -21,11 +20,11 @@
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
-    //"plugin:@typescript-eslint/recommended-requiring-type-checking"
+    "plugin:@typescript-eslint/recommended-requiring-type-checking"
     "standard",
     "plugin:react/recommended",
     "plugin:jsx-a11y/recommended",
-    "prettier/@typescript-eslint", // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
+    "prettier/@typescript-eslint",
     "plugin:prettier/recommended",
     "plugin:import/errors",
     "plugin:import/warnings",
@@ -43,7 +42,7 @@
   },
   "plugins": ["@typescript-eslint/eslint-plugin", "import", "prettier", "standard", "react", "jsx-a11y", "security"],
   "rules": {
-    //"no-unused-variable": "warn",
+    "no-unused-variable": "warn",
     "import/no-unresolved": "error",
     "import/named": "error",
     "import/namespace": "error",

--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
-# tezosacademy
+# Tezos Academy
 
-# start localy the server 
+## Local
 
+Install dependencies:
+
+```sh
+yarn
 ```
+
+Start everything:
+
+```sh
 yarn start
 ```
 
 if you get an error ERR_OSSL_EVP_UNSUPPORTED
-```
+
+```sh
 export NODE_OPTIONS=--openssl-legacy-provider
 ```

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "tezosacademy-frontend",
   "version": "1.0.0",
   "scripts": {
-    "start": "PORT=3000 NODE_ENV=development REACT_APP_BACKEND_URL=http://localhost:8080 react-scripts -r @cypress/instrument-cra start && open http://localhost:3000",
+    "start": "SKIP_PREFLIGHT_CHECK=true PORT=3000 NODE_ENV=development REACT_APP_BACKEND_URL=http://localhost:8080 react-scripts -r @cypress/instrument-cra start && open http://localhost:3000",
     "build": "INLINE_RUNTIME_CHUNK=false react-scripts build && cra-append-sw -s ./src/custom-sw.js",
     "docker-create": "doctl k8s cluster create --region fra1 --node-pool \"name=tezosacademy-frontend;size=s-1vcpu-2gb;count=1;auto-scale=true;min-nodes=1;max-nodes=3\" tezosacademy-frontend --wait && doctl kubernetes cluster kubeconfig save tezosacademy-frontend",
     "docker-build": "yarn build && docker build -t rtx/tezosacademy-frontend . --no-cache",
@@ -54,11 +54,11 @@
     "styled-components": "^5.1.1"
   },
   "devDependencies": {
+    "@cypress/code-coverage": "^3.8.1",
+    "@cypress/instrument-cra": "^1.1.1",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
-    "@cypress/code-coverage": "^3.8.1",
-    "@cypress/instrument-cra": "^1.1.1",
     "@types/history": "^4.7.6",
     "@types/jwt-decode": "^2.2.1",
     "@types/markdown-to-jsx": "^6.11.0",

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -4097,14 +4097,14 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001061:
-  version "1.0.30001078"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001078.tgz#e1b6e2ae327b6a1ec11f65ec7a0dde1e7093074c"
-  integrity sha512-sF12qXe9VMm32IEf/+NDvmTpwJaaU7N1igpiH2FdI4DyABJSsOqG3ZAcFvszLkoLoo1y6VJLMYivukUAxaMASw==
+  version "1.0.30001325"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz"
+  integrity sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==
 
 caniuse-lite@^1.0.30001043:
-  version "1.0.30001048"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001048.tgz#4bb4f1bc2eb304e5e1154da80b93dee3f1cf447e"
-  integrity sha512-g1iSHKVxornw0K8LG9LLdf+Fxnv7T1Z+mMsf0/YYLclQX4Cd522Ap0Lrw6NFqHgezit78dtyWxzlV2Xfc7vgRg==
+  version "1.0.30001325"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz"
+  integrity sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
We currently have this error when using `yarn start` https://stackoverflow.com/questions/54000294/the-react-scripts-package-provided-by-create-react-app-requires-a-dependency

I added `SKIP_PREFLIGHT_CHECK=true` to the script

I also removed comments from `.eslintrc.json` as their are not allowed, also keeping warning about unused variables