### PR TITLE
restore layout

### DIFF
--- a/src/frontend/src/app/App.style.tsx
+++ b/src/frontend/src/app/App.style.tsx
@@ -13,6 +13,9 @@ export const AppBg = styled.div`
 `
 
 export const AppWrapper = styled.div`
+  position: absolute;
+  width: 100vw;
+  top: 0;
   background: url('/images/grid.svg') repeat center top;
   will-change: transform, opacity;
 `

--- a/src/frontend/src/pages/Chapter/Chapter.components/Footer/Footer.style.tsx
+++ b/src/frontend/src/pages/Chapter/Chapter.components/Footer/Footer.style.tsx
@@ -14,12 +14,6 @@ export const FooterStyled = styled.div`
     bottom: 0;
     right: 0;
   }
-
-  @media (max-width: 900px) {
-    > a:nth-child(1) {
-      display: none;
-    }
-  }
 `
 
 export const FooterCredits = styled.div`

--- a/src/frontend/src/pages/ChapterAbout/ChapterAbout.style.tsx
+++ b/src/frontend/src/pages/ChapterAbout/ChapterAbout.style.tsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components/macro'
 
 export const ChapterAboutStyled = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
   height: calc(100vh - 130px);
   margin: 74px 20px 0;
 `
@@ -23,7 +25,6 @@ export const ChapterGrid = styled.div<{ hasTabs?: boolean }>`
   display: grid;
   grid-template-rows: ${(props) => (props.hasTabs ? '30px 500px auto' : '500px auto')};
   grid-gap: 0;
-  overflow-y: scroll;
 
   @media (max-width: 900px) {
     overflow-y: initial;


### PR DESCRIPTION
Sorry should not have removed this in this MR https://github.com/AymericBethencourt/tezos-academy/commit/efa665cde6fbc888799b9bdce5f7175b98be4f4e

The removed code in Footer.style.tsx was hiding "previous" button on small screen, not sure why

The change in ChapterAbout.style.tsx is a fix for the sticky footer

Removed `overflow-y: scroll;` that was causing tabs to be broken on firefox, not sure we really need a horizontal scrollbar, as there is a small device layout