### PR TITLE
empty string for proper type conversion

### DIFF
--- a/src/frontend/src/pages/Chapters/JS/ChapterFunctions/exercise.jsligo
+++ b/src/frontend/src/pages/Chapters/JS/ChapterFunctions/exercise.jsligo
@@ -1,4 +1,5 @@
 type ship_code = string;
 let my_ship: ship_code = "020433";
 // Modify the code below
-my_ship = String.sub(0 as nat, 2 as nat, my_ship) + "1" + String.sub(3 as nat, 3 as nat, my_ship);
+my_ship = "" + String.sub(0 as nat, 2 as nat, my_ship) + "1" + String.sub(3 as nat, 3 as nat, my_ship);
+


### PR DESCRIPTION
I'm just learning JS ligo with the academy and I noticed previous chapter (#5)  says
"If you want to concatenate to substrings you need to add an empty string before the expression to help Ligo make a proper type conversion:"
so that page exercise solution should be the one in line 4 (see also mission point 2)