### PR TITLE
empty string for proper type conversion

### DIFF
--- a/src/frontend/src/pages/Chapters/JS/ChapterConditionals/solution.jsligo
+++ b/src/frontend/src/pages/Chapters/JS/ChapterConditionals/solution.jsligo
@@ -6,7 +6,7 @@ const my_ship_price : tez = 3 as tez * (120 as nat);
 let modify_ship = (my_ship: ship_code): ship_code => {
     // Type your solution below
     if (String.sub(2 as nat, 1 as nat, my_ship) == "0") {
-        return String.sub(0 as nat, 2 as nat, my_ship) + "1" + String.sub(3 as nat, 3 as nat, my_ship);
+        return "" + String.sub(0 as nat, 2 as nat, my_ship) + "1" + String.sub(3 as nat, 3 as nat, my_ship);
     } else {
         return my_ship;
     }


### PR DESCRIPTION
I've already seen it on chapter 6, maybe it's a mistake due to porting the code from another syntax. I'm just learning JS ligo with the academy so if I am going in the wrong direction please stop me.
Chapter (#5) says
"If you want to concatenate to substrings you need to add an empty string before the expression to help Ligo make a proper type conversion:"